### PR TITLE
fix - change the way the log level is mapped

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ class Logger {
             error: 3,
         };
 
-        return logLevels[level] || -1;
+        return logLevels[level] ?? -1;
     }
 
     log(


### PR DESCRIPTION
Problematic case:

Whenever we try to map debug level to it's equivalent number representation (0) and check if it was corrected map by using pipes (`||`) we might receive an undesired behavior:

![image](https://github.com/user-attachments/assets/c5eaacdf-ef28-4a36-a6de-1b3cad9b5944)

Given that, a good alternative is to use nullable coalescing operator (`??`), so in this scenario the problem won't happen:

![image](https://github.com/user-attachments/assets/322e5d3d-468f-4cbe-a9c5-f0d17582bddb)

